### PR TITLE
feat: export relevant constants with time converter class

### DIFF
--- a/src/TimeConverter.ts
+++ b/src/TimeConverter.ts
@@ -9,7 +9,7 @@ export interface TimeConversionResult {
   gnssTime: GnssTime | undefined;
   unixTime: number | undefined;
   leapSeconds: number | undefined;
-  nextLeapYear: number | undefined;
+  nextLeapYear: number;
 }
 
 export const unixAtGpsZero = 315964800;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export {TimeConverter} from './TimeConverter';
+export {TimeConverter, maxTimeOfWeek, unixAtGpsZero} from './TimeConverter';

--- a/test/TimeConverter.test.ts
+++ b/test/TimeConverter.test.ts
@@ -1,4 +1,4 @@
-import {maxTimeOfWeek, TimeConverter, unixAtGpsZero} from "../src/TimeConverter";
+import { maxTimeOfWeek, TimeConverter, unixAtGpsZero } from "../src";
 
 
 describe('TimeConverter', () => {


### PR DESCRIPTION
BREAKING CHANGE: `nextLeapYear` can not be undefined anymore